### PR TITLE
Slimming down environment and improving readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 Intake Examples
 ===============
 
+This repository includes example notebooks and data packages for intake.
+
+They should run locally if you download this repository. They are also available in a running environment on the cloud by clicking on the link below:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/intake/intake-examples/master)
+
+
+## Data Packages
 This directory contains examples of Intake catalogs and scripts:
 
 * [data-us-states](data-us-states/) - Conda data package with embedded data (see docs for more details). Available
@@ -12,6 +20,8 @@ This directory contains examples of Intake catalogs and scripts:
 * [nyc_taxi](nyc_taxi/) - Full cloud-based installable dataset of Taxi trip data in NYC in parquet format. Available
   via `conda install -c intake nyc-taxi`.
 * [precip](precip/) - Precipitation data with example notebook
+
+## Other examples
 
 The following example is an online data-set listing automatically generated from an Intake
 catalog:

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,14 @@
-name: intake-gui
+name: intake-examples
 channels:
   - conda-forge
 dependencies:
   - intake
   - jupyter
   - nodejs
-  - scipy
-  - scikit-image
   - s3fs
   - tqdm
   - intake-xarray
   - bokeh==1.1.0
-  - hvplot==0.4.0
-  - holoviews==1.12.1
-  - panel==0.5.1
+  - pyviz::hvplot==0.4.0
+  - pyviz::holoviews==1.12.1
+  - pyviz::panel==0.5.1


### PR DESCRIPTION
I think we should go with a fairly minimal env until we have a reason to do more. Individual examples should include their own install instructions to reduce bloat.