### PR TITLE
Adding jupyterlab pyviz extension

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+jupyter labextension install @pyviz/jupyterlab_pyviz


### PR DESCRIPTION
I was running through the intake examples on Binder and noticed that the GUI didn't seem to be working. I came across

https://github.com/intake/intake/issues/423

and wonder if it isn't working on Binder because the pyviz jupyterlab extension isn't installed. This PR installs the extension for Binder w/ a `postBuild` file.