### PR TITLE
Add entrypoints to driver tutorial

### DIFF
--- a/tutorial/intake-github/setup.py
+++ b/tutorial/intake-github/setup.py
@@ -13,5 +13,10 @@ setup(
     include_package_data=True,
     install_requires=['intake', 'pygithub'],
     long_description="",
+    entry_points={
+        'intake.drivers': [
+            'github_issues = intake_github:GithubIssuesSource',
+        ]
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
Closes #8 

Now, pip-installing in the intake-github directory will add "github_issues" to the intake driver registry.