### PR TITLE
Force jupyterlab 2.X

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,3 +21,4 @@ dependencies:
   - pyviz::holoviews==1.12.2
   - panel==0.5.1
   - datashader==0.7.0
+  - jupyterlab < 3


### PR DESCRIPTION
Just pinning Jupyterlab to 2.X so the pyviz jupyterlab extension will install correctly

Fixes #10 